### PR TITLE
refactor: remove api key

### DIFF
--- a/MovieApp/Config.xcconfig
+++ b/MovieApp/Config.xcconfig
@@ -8,4 +8,5 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-API_KEY = 7553c036701df610e97f386dfece0edd
+/// ADD API KEY
+API_KEY = ADD API KEY 


### PR DESCRIPTION


When I updated the route Config file, I forgot to add the new path to the `.gitignore`. I then had to remove the key and include the new route in the `.gitignore`.






